### PR TITLE
Add pong preference selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ data_*/
 
 # Python
 env/
+
+# ide
+.vscode/

--- a/common/utils/debug/debug_config.gd
+++ b/common/utils/debug/debug_config.gd
@@ -1,4 +1,4 @@
 class_name DebugConfig
 extends Resource
 
-export(GameEnums.LogLevel) var log_level = GameEnums.LogLevel.LASSERT
+export(GameConstants.LogLevel) var log_level = GameConstants.LogLevel.LASSERT

--- a/common/utils/debug/debug_util.gd
+++ b/common/utils/debug/debug_util.gd
@@ -5,10 +5,10 @@ const DEBUG_CONFIG: DebugConfig = preload("res://common/utils/debug/configs/defa
 
 
 static func log(message: String, config: Dictionary = {}) -> void:
-	if !(GameEnums.LOG_LEVEL_KEY in config):
+	if !(GameConstants.LOG_LEVEL_KEY in config):
 		return
 
-	if config[GameEnums.LOG_LEVEL_KEY] < DEBUG_CONFIG.log_level:
+	if config[GameConstants.LOG_LEVEL_KEY] < DEBUG_CONFIG.log_level:
 		return
 
 	print(message)

--- a/common/utils/game_enums.gd
+++ b/common/utils/game_enums.gd
@@ -1,10 +1,8 @@
 extends Node
 
-enum ControlScheme {
-	PLAYER,
-	ENEMY,
-}
+# gdlint: disable = class-definitions-order
 
+# region Universal
 enum LogLevel {
 	INHERIT = -1,
 	OFF = 0,
@@ -19,3 +17,17 @@ enum LogLevel {
 }
 
 const LOG_LEVEL_KEY = "LogLevel"
+# endregion Universal
+
+# region General
+enum ControlScheme {
+	PLAYER,
+	ENEMY,
+}
+# endregion General
+
+# region Pong
+enum PongMode { MULTIPLAYER, SINGLEPLAYER }
+# endregion Pong
+
+# gdlint: enable=class-definitions-order

--- a/common/utils/input_util.gd
+++ b/common/utils/input_util.gd
@@ -1,8 +1,8 @@
 class_name InputUtil
 
 const CONTROL_SCHEME_DICT = {
-	GameEnums.ControlScheme.ENEMY: "enemy",
-	GameEnums.ControlScheme.PLAYER: "ui",
+	GameConstants.ControlScheme.ENEMY: "enemy",
+	GameConstants.ControlScheme.PLAYER: "ui",
 }
 
 
@@ -11,7 +11,7 @@ static func get_prefix(scheme: int) -> String:
 	if not scheme in CONTROL_SCHEME_DICT:
 		DebugUtil.log(
 			"InputUtil: get_prefix: invalid scheme: %d. Defaulting to PLAYER" % scheme,
-			{GameEnums.LOG_LEVEL_KEY: GameEnums.LogLevel.ERROR}
+			{GameConstants.LOG_LEVEL_KEY: GameConstants.LogLevel.ERROR}
 		)
-		return GameEnums.ControlScheme.PLAYER
+		return GameConstants.ControlScheme.PLAYER
 	return CONTROL_SCHEME_DICT[scheme]

--- a/common/utils/scene_util.gd
+++ b/common/utils/scene_util.gd
@@ -3,7 +3,10 @@ extends Node
 # gdlint:ignore = max-line-length
 # taken from: https://docs.godotengine.org/en/3.1/getting_started/step_by_step/singletons_autoload.html#global-gd
 
+const KEY_PONG_MODE = "pong_mode"
+
 var current_scene: Node = null
+var current_args: Dictionary = {}
 
 
 func _ready():
@@ -11,20 +14,21 @@ func _ready():
 	current_scene = root.get_child(root.get_child_count() - 1)
 
 
-func goto_scene(path) -> void:
+func goto_scene(path: String, args: Dictionary = {}) -> void:
 	# This function will usually be called from a signal callback,
 	# or some other function in the current scene.
 	# Deleting the current scene at this point is
 	# a bad idea, because it may still be executing code.
 	# This will result in a crash or unexpected behavior.
 
+	current_args = args
+
 	# The solution is to defer the load to a later time, when
 	# we can be sure that no code from the current scene is running:
-
 	call_deferred("_deferred_goto_scene", path)
 
 
-func _deferred_goto_scene(path) -> void:
+func _deferred_goto_scene(path: String) -> void:
 	# It is now safe to remove the current scene
 	current_scene.free()
 

--- a/project.godot
+++ b/project.godot
@@ -28,12 +28,30 @@ _global_script_classes=[ {
 "class": "PaddleController",
 "language": "GDScript",
 "path": "res://scenes/simple_pong/components/paddle/paddle_controller.gd"
+}, {
+"base": "Node",
+"class": "PongMenu",
+"language": "GDScript",
+"path": "res://scenes/simple_pong/menu/pong_menu.gd"
+}, {
+"base": "Reference",
+"class": "SimplePong",
+"language": "GDScript",
+"path": "res://scenes/simple_pong/simple_pong.gd"
+}, {
+"base": "Reference",
+"class": "SimplePongMeta",
+"language": "GDScript",
+"path": "res://scenes/simple_pong/simple_pong_meta.gd"
 } ]
 _global_script_class_icons={
 "DebugConfig": "",
 "DebugUtil": "",
 "InputUtil": "",
-"PaddleController": ""
+"PaddleController": "",
+"PongMenu": "",
+"SimplePong": "",
+"SimplePongMeta": ""
 }
 
 [application]
@@ -44,7 +62,7 @@ config/icon="res://icon.png"
 
 [autoload]
 
-GameEnums="*res://common/utils/game_enums.gd"
+GameConstants="*res://common/utils/game_enums.gd"
 SceneUtil="*res://common/utils/scene_util.gd"
 
 [display]

--- a/project.godot
+++ b/project.godot
@@ -28,12 +28,18 @@ _global_script_classes=[ {
 "class": "PaddleBehaviorUtil",
 "language": "GDScript",
 "path": "res://scenes/simple_pong/components/paddle/paddle_behavior_util.gd"
+}, {
+"base": "KinematicBody2D",
+"class": "PaddleController",
+"language": "GDScript",
+"path": "res://scenes/simple_pong/components/paddle/paddle_controller.gd"
 } ]
 _global_script_class_icons={
 "DebugConfig": "",
 "DebugUtil": "",
 "InputUtil": "",
-"PaddleBehaviorUtil": ""
+"PaddleBehaviorUtil": "",
+"PaddleController": ""
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -24,11 +24,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://common/utils/input_util.gd"
 }, {
-"base": "Reference",
-"class": "PaddleBehaviorUtil",
-"language": "GDScript",
-"path": "res://scenes/simple_pong/components/paddle/paddle_behavior_util.gd"
-}, {
 "base": "KinematicBody2D",
 "class": "PaddleController",
 "language": "GDScript",
@@ -38,7 +33,6 @@ _global_script_class_icons={
 "DebugConfig": "",
 "DebugUtil": "",
 "InputUtil": "",
-"PaddleBehaviorUtil": "",
 "PaddleController": ""
 }
 

--- a/project.godot
+++ b/project.godot
@@ -23,11 +23,17 @@ _global_script_classes=[ {
 "class": "InputUtil",
 "language": "GDScript",
 "path": "res://common/utils/input_util.gd"
+}, {
+"base": "Reference",
+"class": "PaddleBehaviorUtil",
+"language": "GDScript",
+"path": "res://scenes/simple_pong/components/paddle/paddle_behavior_util.gd"
 } ]
 _global_script_class_icons={
 "DebugConfig": "",
 "DebugUtil": "",
-"InputUtil": ""
+"InputUtil": "",
+"PaddleBehaviorUtil": ""
 }
 
 [application]

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -2,4 +2,4 @@ extends Node
 
 
 func _on_PongButton_pressed():
-	SceneUtil.goto_scene("res://scenes/simple_pong/SimplePong.tscn")
+	SceneUtil.goto_scene(PongMenu.get_scene_path())

--- a/scenes/simple_pong/SimplePong.tscn
+++ b/scenes/simple_pong/SimplePong.tscn
@@ -1,17 +1,20 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://scenes/simple_pong/components/paddle/Paddle.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/simple_pong/components/ball/Ball.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/simple_pong/components/Wall.tscn" type="PackedScene" id=3]
+[ext_resource path="res://scenes/simple_pong/components/paddle/behavior/paddle_keyboard_input.gd" type="Script" id=4]
 
 [node name="Node2D" type="Node2D"]
 
 [node name="PlayerPaddle" parent="." instance=ExtResource( 1 )]
 position = Vector2( 40, 90 )
+behavior_script = ExtResource( 4 )
 
 [node name="EnemyPaddle" parent="." instance=ExtResource( 1 )]
 position = Vector2( 280, 90 )
 control_scheme = 1
+behavior_script = ExtResource( 4 )
 
 [node name="Ball" parent="." instance=ExtResource( 2 )]
 position = Vector2( 160, 90 )

--- a/scenes/simple_pong/components/paddle/behavior/paddle_keyboard_input.gd
+++ b/scenes/simple_pong/components/paddle/behavior/paddle_keyboard_input.gd
@@ -1,0 +1,16 @@
+extends Node
+
+var up_key: String = "ui_up"
+var down_key: String = "ui_down"
+
+
+func initialize(paddle: PaddleController) -> void:
+	var prefix: String = InputUtil.get_prefix(paddle.control_scheme)
+	up_key = "%s_up" % prefix
+	down_key = "%s_down" % prefix
+
+
+func act(paddle: PaddleController, delta: float) -> Vector2:
+	var input_value: Vector2 = Vector2.ZERO
+	input_value.y = Input.get_action_strength(down_key) - Input.get_action_strength(up_key)
+	return input_value * delta * paddle.input_strength

--- a/scenes/simple_pong/components/paddle/behavior/paddle_simple_ai.gd
+++ b/scenes/simple_pong/components/paddle/behavior/paddle_simple_ai.gd
@@ -1,14 +1,9 @@
 extends Node
 
-# Declare member variables here. Examples:
-# var a = 2
-# var b = "text"
+
+func initialize(_paddle: PaddleController) -> void:
+	pass
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass  # Replace with function body.
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#    pass
+func act(_paddle: PaddleController, _delta: float) -> Vector2:
+	return Vector2.ZERO

--- a/scenes/simple_pong/components/paddle/behavior/paddle_simple_ai.gd
+++ b/scenes/simple_pong/components/paddle/behavior/paddle_simple_ai.gd
@@ -1,0 +1,14 @@
+extends Node
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass  # Replace with function body.
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#    pass

--- a/scenes/simple_pong/components/paddle/paddle_controller.gd
+++ b/scenes/simple_pong/components/paddle/paddle_controller.gd
@@ -1,21 +1,22 @@
+class_name PaddleController
 extends KinematicBody2D
 
 export(float) var input_strength = 4.0
 export(GameEnums.ControlScheme) var control_scheme = GameEnums.ControlScheme.PLAYER
+export(Script) var behavior_script
 
-var up_key: String = "ui_up"
-var down_key: String = "ui_down"
+var behavior = null
 
 
 func _ready():
-	var prefix: String = InputUtil.get_prefix(control_scheme)
-	up_key = "%s_up" % prefix
-	down_key = "%s_down" % prefix
+	assert(behavior_script != null)
+	behavior = behavior_script.new()
+	assert(behavior.has_method("initialize"))
+	assert(behavior.has_method("act"))
+	behavior.initialize(self)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	var input_value: Vector2 = Vector2.ZERO
-	input_value.y = Input.get_action_strength(down_key) - Input.get_action_strength(up_key)
 	# warning-ignore:return_value_discarded
-	move_and_collide(input_value * delta * input_strength)
+	move_and_collide(behavior.act(self, delta))

--- a/scenes/simple_pong/components/paddle/paddle_controller.gd
+++ b/scenes/simple_pong/components/paddle/paddle_controller.gd
@@ -1,14 +1,26 @@
 class_name PaddleController
 extends KinematicBody2D
 
+enum BehaviorType { HUMAN, AI }
+
 export(float) var input_strength = 4.0
-export(GameEnums.ControlScheme) var control_scheme = GameEnums.ControlScheme.PLAYER
+export(BehaviorType) var behavior_type = BehaviorType.HUMAN
+export(GameConstants.ControlScheme) var control_scheme = GameConstants.ControlScheme.PLAYER
 export(Script) var behavior_script
 
 var behavior = null
 
 
 func _ready():
+	if (
+		control_scheme == GameConstants.ControlScheme.ENEMY
+		and SceneUtil.KEY_PONG_MODE in SceneUtil.current_args
+		and SceneUtil.current_args[SceneUtil.KEY_PONG_MODE] == GameConstants.PongMode.SINGLEPLAYER
+	):
+		behavior_script = load(
+			"res://scenes/simple_pong/components/paddle/behavior/paddle_simple_ai.gd"
+		)
+
 	assert(behavior_script != null)
 	behavior = behavior_script.new()
 	assert(behavior.has_method("initialize"))

--- a/scenes/simple_pong/menu/PongMenu.tscn
+++ b/scenes/simple_pong/menu/PongMenu.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/simple_pong/menu/pong_menu.gd" type="Script" id=1]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+margin_right = 320.0
+margin_bottom = 180.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+margin_left = 113.0
+margin_top = 39.0
+margin_right = 206.0
+margin_bottom = 141.0
+size_flags_vertical = 0
+custom_constants/separation = 8
+
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer"]
+margin_right = 93.0
+margin_bottom = 46.0
+rect_min_size = Vector2( 0, 46 )
+text = "Pong yeah..."
+align = 1
+
+[node name="SinglePlayerButton" type="Button" parent="CenterContainer/VBoxContainer"]
+margin_top = 54.0
+margin_right = 93.0
+margin_bottom = 74.0
+text = "Single player"
+
+[node name="MultiplayerButton" type="Button" parent="CenterContainer/VBoxContainer"]
+margin_top = 82.0
+margin_right = 93.0
+margin_bottom = 102.0
+text = "Multiplayer"
+
+[connection signal="pressed" from="CenterContainer/VBoxContainer/SinglePlayerButton" to="." method="_on_SinglePlayerButton_pressed"]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/MultiplayerButton" to="." method="_on_MultiplayerButton_pressed"]

--- a/scenes/simple_pong/menu/pong_menu.gd
+++ b/scenes/simple_pong/menu/pong_menu.gd
@@ -1,0 +1,20 @@
+class_name PongMenu
+extends Node
+
+
+static func get_scene_path() -> String:
+	return "res://scenes/simple_pong/menu/PongMenu.tscn"
+
+
+func _on_SinglePlayerButton_pressed():
+	var meta = SimplePongMeta.get_resource()
+	var meta_obj = meta.new()
+	meta_obj.pong_mode = GameConstants.PongMode.SINGLEPLAYER
+	SceneUtil.goto_scene(SimplePong.get_scene_path(), meta_obj.to_dictionary())
+
+
+func _on_MultiplayerButton_pressed():
+	var meta = SimplePongMeta.get_resource()
+	var meta_obj = meta.new()
+	meta_obj.pong_mode = GameConstants.PongMode.MULTIPLAYER
+	SceneUtil.goto_scene(SimplePong.get_scene_path(), meta_obj.to_dictionary())

--- a/scenes/simple_pong/simple_pong.gd
+++ b/scenes/simple_pong/simple_pong.gd
@@ -1,0 +1,5 @@
+class_name SimplePong
+
+
+static func get_scene_path() -> String:
+	return "res://scenes/simple_pong/SimplePong.tscn"

--- a/scenes/simple_pong/simple_pong_meta.gd
+++ b/scenes/simple_pong/simple_pong_meta.gd
@@ -1,0 +1,11 @@
+class_name SimplePongMeta
+
+var pong_mode = GameConstants.PongMode.MULTIPLAYER
+
+
+static func get_resource() -> Resource:
+	return load("res://scenes/simple_pong/simple_pong_meta.gd")
+
+
+func to_dictionary() -> Dictionary:
+	return {SceneUtil.KEY_PONG_MODE: pong_mode}


### PR DESCRIPTION
## What's this change for?
This closes #20 .

## Detailed description
- Add pong mode selection
- Move input logic away from the paddle controller and wrapped inside a generic behavior interface
- Refactor some constants into GameConstants (previously GameEnums)

## Testing
- [x] Check out the two modes and see if it affects how the paddles move

## What I learned
- How to tame Godot's [duck typing](https://docs.godotengine.org/en/stable/tutorials/best_practices/godot_interfaces.html)