### PR TITLE
Upgrade GDToolkit to Godot 4.0 beta 2

### DIFF
--- a/.github/workflows/gdlint-check-beta.yml
+++ b/.github/workflows/gdlint-check-beta.yml
@@ -1,0 +1,32 @@
+﻿name: GDScript 4.0 beta v2 lint check
+
+on: [ push ]
+
+# References
+# How to fail: https://stackoverflow.com/questions/57903836/how-to-fail-a-job-in-github-actions
+# Base script: https://github.com/actions/starter-workflows/blob/main/ci/pylint.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      #      - uses: actions/checkout@master
+      #        with:
+      #          repository: Scony/godot-gdscript-toolkit
+      #          ref: 8ae0a1e8e6ce564604dd9f200cc6e5cfe0a982d8 # https://github.com/Scony/godot-gdscript-toolkit/commit/8ae0a1e8e6ce564604dd9f200cc6e5cfe0a982d8
+      #          github-server-url: https://github.com
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          git clone https://github.com/Scony/godot-gdscript-toolkit.git
+          pip install -e godot-gdscript-toolkit
+      - name: Running GDToolkit lint analysis
+        run: |
+          gdlint common scenes

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ env/
 # ide
 .vscode/
 .idea/
+
+# linting locally for godot 4.0 beta 2
+godot-gdscript-toolkit/

--- a/commands.bash
+++ b/commands.bash
@@ -1,33 +1,41 @@
 # -c = command
 # -c lint = checks for linting errors in the entire godot project
 # -c format = enforces linting in the entire project
+# todo(turnip): more documentation
 
-while getopts c: flag
-do
-    case "${flag}" in
-        c) command=${OPTARG};;
-    esac
+while getopts c: flag; do
+  case "${flag}" in
+  c) command=${OPTARG} ;;
+  *) eval "echo \"invalid flag ${flag}\"" ;;
+  esac
 done
+
+# $1: required argument: gdlint vs gdformat
+run_gdtoolkit() {
+  source env/Scripts/activate # activating bash in Windows 10 Git Bash
+  #  pip3 install 'gdtoolkit==3.*' -q # for stable version
+  python -m pip install --upgrade pip -q
+  if [ ! -d "./godot-gdscript-toolkit" ]; then
+    git clone https://github.com/Scony/godot-gdscript-toolkit.git
+  fi
+  pip3 install -e godot-gdscript-toolkit -q
+  eval "$1 common scenes"
+  deactivate
+}
 
 case $command in
 
-    lint)
-        echo "Checking for formatting problems in Godot files..."
-        source env/Scripts/activate # activating bash in Windows 10 Git Bash
-        pip3 install 'gdtoolkit==3.*' -q
-        gdlint common scenes
-        deactivate
-        ;;
+lint)
+  echo "Checking for formatting problems in Godot files..."
+  run_gdtoolkit "gdlint"
+  ;;
 
-    format)
-        echo "Formatting Godot files..."
-        source env/Scripts/activate # activating bash in Windows 10 Git Bash
-        pip3 install 'gdtoolkit==3.*' -q
-        gdformat common scenes
-        deactivate
-        ;;
+format)
+  echo "Formatting Godot files..."
+  run_gdtoolkit "gdformat"
+  ;;
 
-    *)
-        echo -n "unknown"
-        ;;
+*)
+  echo -n "unknown"
+  ;;
 esac

--- a/common/utils/debug/debug_config.gd
+++ b/common/utils/debug/debug_config.gd
@@ -1,4 +1,4 @@
 class_name DebugConfig
 extends Resource
 
-@export var log_level = GameConstants.LogLevel.LASSERT # (GameConstants.LogLevel)
+@export var log_level = GameConstants.LogLevel.LASSERT  # (GameConstants.LogLevel)

--- a/common/utils/debug/debug_util.gd
+++ b/common/utils/debug/debug_util.gd
@@ -1,7 +1,9 @@
 class_name DebugUtil
 
 # gdlint:ignore = max-line-length
-const DEBUG_CONFIG: DebugConfig = preload("res://common/utils/debug/configs/default_debug_config.tres")
+const DEBUG_CONFIG: DebugConfig = preload(
+	"res://common/utils/debug/configs/default_debug_config.tres"
+)
 
 
 static func log(message: String, config: Dictionary = {}) -> void:

--- a/docs/godot-4.0-beta-guide.md
+++ b/docs/godot-4.0-beta-guide.md
@@ -1,0 +1,11 @@
+﻿# Godot 4.0 Beta
+
+## Linting with GDToolkit
+
+GDToolkit 4.0 isn't available in pip so you have to pull the repo to get it.
+
+```bash
+git clone git@github.com:Scony/godot-gdscript-toolkit.git
+pip install -e godot-gdscript-toolkit/
+gdformat common scenes # proceed as normal
+```

--- a/scenes/simple_pong/components/ball/ball_controller.gd
+++ b/scenes/simple_pong/components/ball/ball_controller.gd
@@ -18,11 +18,11 @@ var _should_start_process: bool = false
 
 func _ready():
 	# validation
-	assert(ball_speed > 0) #,"ball_speed should be a positive number")
-	assert(min_velocity.x >= 0) #,"min_velocity.x must be greater than 0")
-	assert(min_velocity.y > 0) #,"min_velocity.y must be greater than 0")
-	assert(min_velocity.x <= max_velocity.x) #,"min_velocity.x cannot be bigger than max_velocity.x")
-	assert(min_velocity.y <= max_velocity.y) #,"min_velocity.y cannot be bigger than max_velocity.y")
+	assert(ball_speed > 0)  #,"ball_speed should be a positive number")
+	assert(min_velocity.x >= 0)  #,"min_velocity.x must be greater than 0")
+	assert(min_velocity.y > 0)  #,"min_velocity.y must be greater than 0")
+	assert(min_velocity.x <= max_velocity.x)  #,"min_velocity.x cannot be bigger than max_velocity.x")
+	assert(min_velocity.y <= max_velocity.y)  #,"min_velocity.y cannot be bigger than max_velocity.y")
 
 	# setup
 	_current_velocity = _randomize_velocity()

--- a/scenes/simple_pong/components/paddle/paddle_controller.gd
+++ b/scenes/simple_pong/components/paddle/paddle_controller.gd
@@ -1,14 +1,14 @@
 class_name PaddleController
 extends CharacterBody2D
 
-enum BehaviorType { HUMAN, AI }
-
 @export var input_strength: float = 4.0
 @export var behavior_type: BehaviorType = BehaviorType.HUMAN
-@export var control_scheme = GameConstants.ControlScheme.PLAYER # (GameConstants.ControlScheme)
+@export var control_scheme = GameConstants.ControlScheme.PLAYER  # (GameConstants.ControlScheme)
 @export var behavior_script: Script
 
 var behavior = null
+
+enum BehaviorType { HUMAN, AI }
 
 
 func set_behavior(behavior_):

--- a/scenes/simple_pong/components/pong_round/pong_round.gd
+++ b/scenes/simple_pong/components/pong_round/pong_round.gd
@@ -2,7 +2,7 @@ class_name PongRound
 extends Node
 
 @export var score_delay_duration: float = 3.0
-@export var player_objects: Array[Resource] # (Array, Resource)
+@export var player_objects: Array[Resource]  # (Array, Resource)
 @export var ball_path: NodePath
 @export var score_path: NodePath
 
@@ -45,6 +45,7 @@ func inform_done():
 	score.show()
 	timer.wait_time = score_delay_duration
 	timer.start()
+	# gdlint:ignore = expression-not-assigned
 	await timer.timeout
 	score.hide()
 	game.end_round()


### PR DESCRIPTION
## What's this change for?
Github actions is failing for #51. This should fix that.

## Detailed description
- Add new github actions workflow that uses the godot 4.0 version of gdtoolkit
- In Github, disable the normal linting workflow
- Apply new lint rules for Godot 4.0
- Use the new gdtoolkit in `commands.bash`

## Testing
- [x] Test using act, the github action local tester

## Documentation
- Added a new document called `godot-4.0-beta-guide.md` to list non-standard, undocumented workflows for Godot 4.0. This starts with using gdtoolkit.

## Today we learned:
- functions in bash
- pip installing local plugins