### PR TITLE
Add lives

### DIFF
--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/Augmentions.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/Augmentions.cs
@@ -13,4 +13,11 @@ public partial class Augmentions : Node
 	public override void _Process(double delta)
 	{
 	}
+
+	public Augmentions Reinitialize()
+	{
+		var duplicate = (Augmentions)Duplicate();
+		QueueFree();
+		return duplicate;
+	}
 }

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/Ball.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/Ball.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Godot;
 
@@ -20,20 +21,28 @@ public partial class Ball : CharacterBody2D
     [Export]
     public Node2D Follow;
 
+    [Signal]
+    public delegate void BallWasDoneEventHandler();
+
     private bool _shouldStop = true;
     private Vector2 _currentVelocity;
     private RandomNumberGenerator _rng = new();
-
-    [Signal]
-    public delegate void BallWasDoneEventHandler();
+    private Vector2 _startingPosition;
+    private bool _isDone = false;
 
     public override void _Ready()
     {
         Debug.Assert(Follow != null);
+        _startingPosition = Position;
     }
 
     public override void _Process(double delta)
     {
+        if (_isDone)
+        {
+            return;
+        }
+        
         if (_shouldStop)
         {
             Position = new Vector2(Follow.Position.x, Position.y);
@@ -43,12 +52,14 @@ public partial class Ball : CharacterBody2D
         // judge
         if (Position.y > KillZoneY)
         {
-            EmitSignal("BallWasDone");
-            Free();
+            EmitSignal(SignalName.BallWasDone);
+            _isDone = true;
+            return;
         }
 
         // move
         Velocity = _currentVelocity * (float)delta * BallSpeed;
+
         MoveAndSlide();
         if (GetSlideCollisionCount() > 0)
         {
@@ -87,5 +98,15 @@ public partial class Ball : CharacterBody2D
     public void Stop()
     {
         // todo(turnip)
+    }
+
+    public Ball Reinitialize(PaddlePawn paddlePawn)
+    {
+        var duplicate = (Ball)Duplicate();
+        GD.Print(_startingPosition);
+        duplicate.Position = _startingPosition;
+        duplicate.Follow = paddlePawn;
+        QueueFree();
+        return duplicate;
     }
 }

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/BreakoutRound.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/BreakoutRound.cs
@@ -9,13 +9,20 @@ public partial class BreakoutRound : Node
     [Export]
     public PackedScene TargetOriginal;
 
+    [Export]
+    public Player Player;
+    
+    private const int MaxLives = 3;
+    
     private Node2D _initialTarget = null;
     private int _targetCount = 0;
+    private int _currentLives = MaxLives;
 
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {
         Debug.Assert(TargetOriginal != null);
+        Debug.Assert(Player != null);
         Initialize();
     }
 
@@ -59,7 +66,7 @@ public partial class BreakoutRound : Node
 
     private void TargetKilled()
     {
-        GD.Print("Hi!");
+        GD.Print("Target killed! TODO");
         _targetCount--;
         if (_targetCount <= 0)
         {
@@ -76,7 +83,14 @@ public partial class BreakoutRound : Node
 
     private void InformBallWasDone()
     {
-        // todo(turnip)
+        _currentLives--;
         GD.Print("Done?");
+        if (_currentLives <= 0)
+        {
+            GD.Print("TODO: Game ending! Inform someone about results");
+            return;
+        }
+        
+        Player.Reinitialize(this);
     }
 }

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/BreakoutRound.tscn
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/BreakoutRound.tscn
@@ -9,9 +9,10 @@
 [ext_resource type="Script" path="res://Scripts/Scenes/Breakout/BreakoutGame/Components/Player.cs" id="7_d4wuv"]
 [ext_resource type="PackedScene" uid="uid://cpla5273fbsqu" path="res://Scripts/Scenes/Breakout/BreakoutGame/Components/Target.tscn" id="8_sxm4t"]
 
-[node name="BreakoutRound" type="Node2D"]
+[node name="BreakoutRound" type="Node2D" node_paths=PackedStringArray("Player")]
 script = ExtResource("1_ftu6i")
 TargetOriginal = ExtResource("8_sxm4t")
+Player = NodePath("Player")
 
 [node name="Augmentations" type="Node" parent="."]
 script = ExtResource("2_2tdfl")
@@ -48,7 +49,7 @@ InputStrength = 160.0
 [node name="Ball" parent="." node_paths=PackedStringArray("Follow") instance=ExtResource("3_yw3hf")]
 position = Vector2(213, 322)
 script = ExtResource("5_f2od1")
-BallSpeed = 1250.0
+BallSpeed = 1500.0
 KillZoneY = 370.0
 Follow = NodePath("../Paddle")
 
@@ -59,10 +60,11 @@ offset_right = 573.0
 offset_bottom = 92.0
 text = "Testing"
 
-[node name="Player" type="Node" parent="." node_paths=PackedStringArray("Ball", "Paddle")]
+[node name="Player" type="Node" parent="." node_paths=PackedStringArray("Ball", "Paddle", "Augmentions")]
 script = ExtResource("7_d4wuv")
 Ball = NodePath("../Ball")
 Paddle = NodePath("../Paddle")
+Augmentions = NodePath("../Augmentations")
 
 [connection signal="BallWasDone" from="Ball" to="." method="InformBallWasDone"]
 [connection signal="pressed" from="Button" to="." method="Test"]

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/PaddlePawn.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/PaddlePawn.cs
@@ -7,16 +7,30 @@ public partial class PaddlePawn : CharacterBody2D
     [Export]
     public float InputStrength = 4.0f;
 
-    private Vector2 _currentInput;
+    private Vector2 _currentPosition;
+    private Vector2 _startingPosition;
+
+    public override void _Ready()
+    {
+        _startingPosition = Position;
+    }
 
 
     public override void _Process(double delta)
     {
-        MoveAndCollide(_currentInput * (float)delta * InputStrength);
+        MoveAndCollide(_currentPosition * (float)delta * InputStrength);
     }
 
     public void SetInput(Vector2 input)
     {
-        _currentInput = input;
+        _currentPosition = input;
+    }
+
+    public PaddlePawn Reinitialize()
+    {
+        var duplicate = (PaddlePawn)Duplicate();
+        duplicate.Position = _startingPosition;
+        QueueFree();
+        return duplicate;
     }
 }

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/Player.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/Player.cs
@@ -11,10 +11,14 @@ public partial class Player : Node
 	[Export]
 	public PaddlePawn Paddle;
 
+	[Export]
+	public Augmentions Augmentions;
+
 	public override void _Ready()
 	{
 		Debug.Assert(Ball != null);
 		Debug.Assert(Paddle != null);
+		Debug.Assert(Augmentions != null);
 	}
 
 	public override void _Process(double delta)
@@ -27,5 +31,17 @@ public partial class Player : Node
 		var inputValue = Vector2.Zero;
 		inputValue.x = Input.GetActionStrength("ui_right") - Input.GetActionStrength("ui_left");
 		Paddle.SetInput(inputValue);
+	}
+
+	public void Reinitialize(BreakoutRound breakoutRound)
+	{
+		Paddle = Paddle.Reinitialize();
+		breakoutRound.AddChild(Paddle);
+		
+		Ball = Ball.Reinitialize(Paddle);
+		breakoutRound.AddChild(Ball);
+
+		Augmentions = Augmentions.Reinitialize();
+		breakoutRound.AddChild(Augmentions);
 	}
 }

--- a/Scripts/Scenes/Breakout/BreakoutGame/Components/Target.cs
+++ b/Scripts/Scenes/Breakout/BreakoutGame/Components/Target.cs
@@ -4,10 +4,8 @@ namespace GodotExploration.Scripts.Scenes.Breakout.BreakoutGame.Components;
 
 public partial class Target : StaticBody2D
 {
-    // todo(turnip): generate color depending on lives
-    // todo(turnip): lives
-    private const int maxLives = 3;
-    private int currentLives = maxLives;
+    private const int MaxLives = 3;
+    private int _currentLives = MaxLives;
     private Color _additionalColor;
     private Sprite2D _sprite2D;
     
@@ -21,9 +19,9 @@ public partial class Target : StaticBody2D
         UpdateColor();
     }
 
-    public void UpdateColor()
+    private void UpdateColor()
     {
-        var baseColorValue = (currentLives / (float)(maxLives + 1)) * .5f;
+        var baseColorValue = (_currentLives / (float)(MaxLives + 1)) * .5f;
         var r = 2f +  _additionalColor.r*.7f;
         var g = baseColorValue + (1 - baseColorValue) * _additionalColor.g;
         var b = baseColorValue + (1 - baseColorValue) * _additionalColor.b;
@@ -39,11 +37,11 @@ public partial class Target : StaticBody2D
 
     public void Hit()
     {
-        currentLives--;
-        if (currentLives <= 0)
+        _currentLives--;
+        if (_currentLives <= 0)
         {
             QueueFree();
-            EmitSignal("Killed");
+            EmitSignal(SignalName.Killed);
             return;
         }
         


### PR DESCRIPTION
## What's this change for?
This closes #62.

## Detailed description
- Add lives in BreakoutRound
- Add reset for Paddle, Ball, and Augmentations
- Use the strings generated for signals in `SignalName`